### PR TITLE
Refactor getting single post from Parse to use getInBackground with

### DIFF
--- a/app/src/main/java/com/mycompany/traveljournal/datasource/ImageUploader.java
+++ b/app/src/main/java/com/mycompany/traveljournal/datasource/ImageUploader.java
@@ -7,12 +7,9 @@ import com.mycompany.traveljournal.models.Post;
 import com.mycompany.traveljournal.service.JournalApplication;
 import com.mycompany.traveljournal.service.JournalCallBack;
 import com.mycompany.traveljournal.service.JournalService;
-import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.SaveCallback;
-
-import java.util.List;
 
 public class ImageUploader {
 
@@ -58,10 +55,9 @@ public class ImageUploader {
      */
     private void setImageUrlOnPost() {
 
-        client.getPostWithId(postId, new JournalCallBack<List<Post>>() {
+        client.getPostWithId(postId, new JournalCallBack<Post>() {
             @Override
-            public void onSuccess(List<Post> posts) {
-                Post post = posts.get(0);
+            public void onSuccess(Post post) {
                 post.put("image_url", imageUrl);
                 post.saveInBackground();
             }

--- a/app/src/main/java/com/mycompany/traveljournal/datasource/ParseClient.java
+++ b/app/src/main/java/com/mycompany/traveljournal/datasource/ParseClient.java
@@ -75,16 +75,14 @@ public class ParseClient implements JournalService {
 
     }
 
-    public void getPostWithId(String postId, final JournalCallBack<List<Post>> journalCallBack) {
+    public void getPostWithId(String postId, final JournalCallBack<Post> journalCallBack) {
         ParseQuery<Post> query = ParseQuery.getQuery(Post.class);
-        query.whereEqualTo("objectId", postId);
-        query.setLimit(1);
         query.include("parse_user");
-        query.findInBackground(new FindCallback<Post>() {
+        query.getInBackground(postId, new GetCallback<Post>() {
             @Override
-            public void done(List<Post> resultPosts, ParseException e) {
+            public void done(Post post, ParseException e) {
                 if (e == null) {
-                    journalCallBack.onSuccess(resultPosts);
+                    journalCallBack.onSuccess(post);
                 } else {
                     journalCallBack.onFailure(e);
                 }
@@ -281,7 +279,7 @@ public class ParseClient implements JournalService {
                 if (e == null) {
                     Log.wtf(TAG, "Successfully saved comment");
                 } else {
-                    Log.wtf(TAG, "Failed to save comment"+e.toString());
+                    Log.wtf(TAG, "Failed to save comment" + e.toString());
                 }
             }
         });
@@ -302,12 +300,12 @@ public class ParseClient implements JournalService {
             public void done(ParseUser curParseUser, ParseException e) {
 
                 if (e != null) {
-                    Log.wtf(TAG, "Couldnt get parse user: "+e.toString());
+                    Log.wtf(TAG, "Couldnt get parse user: " + e.toString());
                 }
 
                 // Store the current Parse User
                 parseUser = curParseUser;
-                Log.wtf(TAG, "parse user name is "+parseUser.getString("name"));
+                Log.wtf(TAG, "parse user name is " + parseUser.getString("name"));
 
                 ParseQuery<Comment> query = ParseQuery.getQuery(Comment.class);
                 query.getInBackground(commentId, new GetCallback<Comment>() {
@@ -318,9 +316,9 @@ public class ParseClient implements JournalService {
                             @Override
                             public void done(ParseException e) {
                                 if (e == null) {
-                                    Log.wtf(TAG, "Success: Changed User for Comment "+commentId);
+                                    Log.wtf(TAG, "Success: Changed User for Comment " + commentId);
                                 } else {
-                                    Log.wtf(TAG, "Problem updating user for comment "+commentId);
+                                    Log.wtf(TAG, "Problem updating user for comment " + commentId);
                                 }
                             }
                         });

--- a/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
+++ b/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
@@ -1,7 +1,6 @@
 package com.mycompany.traveljournal.detailsscreen;
 
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -18,14 +17,11 @@ import android.widget.TextView;
 import com.mycompany.traveljournal.R;
 import com.mycompany.traveljournal.helpers.DeviceDimensionsHelper;
 import com.mycompany.traveljournal.mapscreen.SingleMapActivity;
-import com.mycompany.traveljournal.mapscreen.SingleMapFragment;
 import com.mycompany.traveljournal.models.Post;
 import com.mycompany.traveljournal.service.JournalApplication;
 import com.mycompany.traveljournal.service.JournalCallBack;
 import com.mycompany.traveljournal.service.JournalService;
 import com.squareup.picasso.Picasso;
-
-import java.util.List;
 
 
 public class DetailFragment extends Fragment {
@@ -99,10 +95,9 @@ public class DetailFragment extends Fragment {
 
     private void fetchPostAndPopulateViews() {
         JournalService client = JournalApplication.getClient();
-        client.getPostWithId(postId, new JournalCallBack<List<Post>>() {
+        client.getPostWithId(postId, new JournalCallBack<Post>() {
             @Override
-            public void onSuccess(List<Post> posts) {
-                Post post = posts.get(0);
+            public void onSuccess(Post post) {
                 populateViews(post);
             }
             @Override

--- a/app/src/main/java/com/mycompany/traveljournal/examples/ExampleComments.java
+++ b/app/src/main/java/com/mycompany/traveljournal/examples/ExampleComments.java
@@ -27,10 +27,9 @@ public class ExampleComments {
         postId = "4jJZPXv8Zu";
         body = "Outdoor Shopping =)";
 
-        client.getPostWithId(postId, new JournalCallBack<List<Post>>() {
+        client.getPostWithId(postId, new JournalCallBack<Post>() {
             @Override
-            public void onSuccess(List<Post> posts) {
-                Post post = posts.get(0);
+            public void onSuccess(Post post) {
                 client.createComment(post, body);
             }
 

--- a/app/src/main/java/com/mycompany/traveljournal/examples/ExampleGetPostsFromParse.java
+++ b/app/src/main/java/com/mycompany/traveljournal/examples/ExampleGetPostsFromParse.java
@@ -18,10 +18,9 @@ public class ExampleGetPostsFromParse {
 
         String postId = "pD7HdQPTSg";
         JournalService client = JournalApplication.getClient();
-        client.getPostWithId(postId, new JournalCallBack<List<Post>>() {
+        client.getPostWithId(postId, new JournalCallBack<Post>() {
             @Override
-            public void onSuccess(List<Post> posts) {
-                Post post = posts.get(0);
+            public void onSuccess(Post post) {
                 Log.wtf(TAG, post.toString());
                 //Log.wtf(TAG, post.getCreatedByUser().toString());
             }

--- a/app/src/main/java/com/mycompany/traveljournal/mapscreen/SingleMapActivity.java
+++ b/app/src/main/java/com/mycompany/traveljournal/mapscreen/SingleMapActivity.java
@@ -1,13 +1,8 @@
 package com.mycompany.traveljournal.mapscreen;
 
-import android.content.Intent;
-import android.location.Location;
-import android.os.Handler;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdate;
@@ -21,17 +16,11 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.mycompany.traveljournal.R;
-import com.mycompany.traveljournal.common.LocationOnConnectListener;
-import com.mycompany.traveljournal.common.LocationService;
-import com.mycompany.traveljournal.detailsscreen.DetailActivity;
 import com.mycompany.traveljournal.helpers.Util;
 import com.mycompany.traveljournal.models.Post;
 import com.mycompany.traveljournal.service.JournalApplication;
 import com.mycompany.traveljournal.service.JournalCallBack;
 import com.mycompany.traveljournal.service.JournalService;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SingleMapActivity extends ActionBarActivity {
 
@@ -84,10 +73,10 @@ public class SingleMapActivity extends ActionBarActivity {
                 }
             });
 
-            client.getPostWithId(m_postID,new JournalCallBack<List<Post>>() {
+            client.getPostWithId(m_postID,new JournalCallBack<Post>() {
                 @Override
-                public void onSuccess(List<Post> posts) {
-                    m_post = posts.get(0);
+                public void onSuccess(Post post) {
+                    m_post = post;
                     if(m_post!=null){
                         m_location = new LatLng(m_post.getLatitude(), m_post.getLongitude());
                         //make sure map camera goes to target location

--- a/app/src/main/java/com/mycompany/traveljournal/mapscreen/SingleMapFragment.java
+++ b/app/src/main/java/com/mycompany/traveljournal/mapscreen/SingleMapFragment.java
@@ -7,35 +7,24 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.RelativeLayout;
 import android.widget.Toast;
 
-import com.google.android.gms.appindexing.Thing;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.MapView;
-import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
-import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.mycompany.traveljournal.R;
-import com.mycompany.traveljournal.detailsscreen.DetailActivity;
-import com.mycompany.traveljournal.detailsscreen.DetailFragment;
 import com.mycompany.traveljournal.helpers.Util;
-import com.mycompany.traveljournal.mainscreen.MainActivity;
 import com.mycompany.traveljournal.models.Post;
 import com.mycompany.traveljournal.service.JournalApplication;
 import com.mycompany.traveljournal.service.JournalCallBack;
 import com.mycompany.traveljournal.service.JournalService;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by ekucukog on 6/10/2015.
@@ -129,10 +118,10 @@ public class SingleMapFragment extends Fragment {
                 }
             });
 
-            client.getPostWithId(m_postID,new JournalCallBack<List<Post>>() {
+            client.getPostWithId(m_postID,new JournalCallBack<Post>() {
                 @Override
-                public void onSuccess(List<Post> posts) {
-                    m_post = posts.get(0);
+                public void onSuccess(Post post) {
+                    m_post = post;
                     if(m_post!=null){
                         m_location = new LatLng(m_post.getLatitude(), m_post.getLongitude());
                         //make sure map camera goes to target location

--- a/app/src/main/java/com/mycompany/traveljournal/service/JournalService.java
+++ b/app/src/main/java/com/mycompany/traveljournal/service/JournalService.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public interface JournalService {
 
-    public void getPostWithId(String postId, JournalCallBack<List<Post>> journalCallBack);
+    public void getPostWithId(String postId, JournalCallBack<Post> journalCallBack);
 
     public void getPostsNearLocation(double latitude, double longitude, int limit, JournalCallBack<List<Post>> journalCallBack);
 


### PR DESCRIPTION
object id

This makes more sense as ParseQuery.getInBackground() is meant for fetching a single object with a given object ID.
