### PR TITLE
Enable Post sharing as a photo.

### DIFF
--- a/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
+++ b/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
@@ -3,6 +3,7 @@ package com.mycompany.traveljournal.detailsscreen;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
@@ -46,6 +47,7 @@ public class DetailFragment extends TravelBaseFragment {
     //private ImageView ivPost;
     private TextView tvCaption;
     private ImageView ivShare;
+    private ImageView ivSharePhoto;
     private ImageView ivFollow;
     private ImageView ivStar;
     private ImageView ivComment;
@@ -65,6 +67,7 @@ public class DetailFragment extends TravelBaseFragment {
     private LinearLayout llComments;
     JournalService client;
     private ArrayList<String> images = new ArrayList<>();
+    private boolean isShareEnabled = true;
 
     private OpenCommentsListenerInterface openCommentsListener;
 
@@ -93,6 +96,7 @@ public class DetailFragment extends TravelBaseFragment {
         //ivPost = (ImageView) v.findViewById(R.id.ivPost);
         tvCaption = (TextView) v.findViewById(R.id.tvCaption);
         ivShare = (ImageView) v.findViewById(R.id.ivShare);
+        ivSharePhoto = (ImageView) v.findViewById(R.id.ivSharePhoto);
         ivFollow = (ImageView) v.findViewById(R.id.ivFollow);
         ivStar = (ImageView) v.findViewById(R.id.ivStar);
         ivComment = (ImageView) v.findViewById(R.id.ivComment);
@@ -129,6 +133,13 @@ public class DetailFragment extends TravelBaseFragment {
             @Override
             public void onClick(View v) {
                 openCommentsListener.openCommentsScreen(postId);
+            }
+        });
+
+        ivShare.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                sharePost();
             }
         });
 
@@ -219,6 +230,9 @@ public class DetailFragment extends TravelBaseFragment {
                 + latitude + "," + longitude;
         Picasso.with(getActivity()).load(staticMapUrl)
                 .into(ivStaticMap);
+
+        //Load image into placeholder to enable image sharing
+        Picasso.with(getActivity()).load(m_post.getImageUrl()).into(ivSharePhoto);
     }
 
     private void populateNumComments(int numComments) {
@@ -325,6 +339,36 @@ public class DetailFragment extends TravelBaseFragment {
         llComments.removeAllViews();
 
         fetchAndPopulateComments(m_post);
+    }
+
+    // Mostly copied from http://guides.codepath.com/android/Sharing-Content-with-Intents
+    // Can be triggered by a view event such as a button press
+    //
+    // This requires the photo be loaded into an image view, hence the need for the invisible ivSharePhoto
+    //
+    public void sharePost() {
+        if (!isShareEnabled) {
+            return;
+        }
+        isShareEnabled = false;
+
+        // Get access to bitmap image from view
+        ImageView ivImage = (ImageView) getActivity().findViewById(R.id.ivSharePhoto);
+        // Get access to the URI for the bitmap
+        Uri bmpUri = Util.getLocalBitmapUri(ivImage);
+        if (bmpUri != null) {
+            // Construct a ShareIntent with link to image
+            Intent shareIntent = new Intent();
+            shareIntent.setAction(Intent.ACTION_SEND);
+            shareIntent.putExtra(Intent.EXTRA_STREAM, bmpUri);
+            shareIntent.setType("image/*");
+            // Launch sharing dialog for image
+            startActivity(Intent.createChooser(shareIntent, "Share Image"));
+            isShareEnabled = true;
+        } else {
+            // ...sharing failed, handle error
+            isShareEnabled = true;
+        }
     }
 
 }

--- a/app/src/main/java/com/mycompany/traveljournal/helpers/Util.java
+++ b/app/src/main/java/com/mycompany/traveljournal/helpers/Util.java
@@ -7,6 +7,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.location.Address;
 import android.location.Geocoder;
 import android.media.ExifInterface;
@@ -16,6 +18,7 @@ import android.net.Uri;
 import android.os.Environment;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
+import android.widget.ImageView;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
@@ -28,6 +31,7 @@ import com.squareup.picasso.Transformation;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
@@ -217,4 +221,30 @@ public class Util {
         return transformation;
     }
 
+    // Copied from http://guides.codepath.com/android/Sharing-Content-with-Intents
+    // Returns the URI path to the Bitmap displayed in specified ImageView
+    public static Uri getLocalBitmapUri(ImageView imageView) {
+        // Extract Bitmap from ImageView drawable
+        Drawable drawable = imageView.getDrawable();
+        Bitmap bmp = null;
+        if (drawable instanceof BitmapDrawable){
+            bmp = ((BitmapDrawable) imageView.getDrawable()).getBitmap();
+        } else {
+            return null;
+        }
+        // Store image to default external storage directory
+        Uri bmpUri = null;
+        try {
+            File file =  new File(Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_DOWNLOADS), "share_image_" + System.currentTimeMillis() + ".png");
+            file.getParentFile().mkdirs();
+            FileOutputStream out = new FileOutputStream(file);
+            bmp.compress(Bitmap.CompressFormat.PNG, 90, out);
+            out.close();
+            bmpUri = Uri.fromFile(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return bmpUri;
+    }
 }

--- a/app/src/main/res/layout/fragment_post_detail.xml
+++ b/app/src/main/res/layout/fragment_post_detail.xml
@@ -255,4 +255,13 @@
 
     </RelativeLayout>
 </com.nirhart.parallaxscroll.views.ParallaxScrollView>
+
+    <!-- Need invisible ImageView to share post photo -->
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        android:id="@+id/ivSharePhoto"
+        />
+
 </LinearLayout>


### PR DESCRIPTION
The sharing requires a local image so the image is loaded into an invisible
image view, ivSharePhoto so that the photo can be downloaded locally and then
shared.
