### PR TITLE
Show comment locally

### DIFF
--- a/app/src/main/java/com/mycompany/traveljournal/commentscreen/CommentActivity.java
+++ b/app/src/main/java/com/mycompany/traveljournal/commentscreen/CommentActivity.java
@@ -17,6 +17,7 @@ public class CommentActivity extends ActionBarActivity implements CommentFragmen
     String postId;
     ParseClient parseClient;
     private boolean newCommentCreated;
+    private int numNewComments;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,6 +41,7 @@ public class CommentActivity extends ActionBarActivity implements CommentFragmen
         }
 
         newCommentCreated = false;
+        numNewComments = 0;
     }
 
 
@@ -73,6 +75,7 @@ public class CommentActivity extends ActionBarActivity implements CommentFragmen
     public void onBackPressed() {
         Intent data = new Intent();
         data.putExtra("new_comment_created", newCommentCreated);
+        data.putExtra("num_new_comments", numNewComments);
         setResult(RESULT_OK, data);
         finish();
         overridePendingTransition(R.anim.left_in, R.anim.right_out);
@@ -81,5 +84,6 @@ public class CommentActivity extends ActionBarActivity implements CommentFragmen
     @Override
     public void commentCreated() {
         newCommentCreated = true;
+        numNewComments += 1;
     }
 }

--- a/app/src/main/java/com/mycompany/traveljournal/commentscreen/CommentFragment.java
+++ b/app/src/main/java/com/mycompany/traveljournal/commentscreen/CommentFragment.java
@@ -22,6 +22,7 @@ import com.mycompany.traveljournal.models.Comment;
 import com.mycompany.traveljournal.service.JournalApplication;
 import com.mycompany.traveljournal.service.JournalCallBack;
 import com.mycompany.traveljournal.service.JournalService;
+import com.parse.ParseUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -138,37 +139,42 @@ public class CommentFragment extends TravelBaseFragment {
             return;
         }
 
-        Log.wtf(TAG, "Creating a comment="+commentText);
+        //Add comment locally
+        addCommentLocally(commentText);
+
         // Hide the keyboard
         hideSoftKeyboard(v);
 
         // Clear the contents
         etAddComment.setText("");
 
-        showProgress();
-
+        // Tell listener that a comment was created
         newCommentListener.commentCreated();
 
         client.createComment(postId, commentText, new JournalCallBack<Comment>() {
             @Override
             public void onSuccess(Comment comment) {
                 Log.wtf(TAG, "Yay! Created comment "+comment.getBody());
-
-                // Add the comment to the adapter
-                aComments.add(comment);
-
-                scrollToMostRecentComment();
-
-                hideProgress();
             }
 
             @Override
             public void onFailure(Exception e) {
                 Log.wtf(TAG, "Can't create comment");
-                hideProgress();
             }
         });
 
+    }
+
+    private void addCommentLocally(String body) {
+
+        Comment comment = new Comment();
+
+        comment.put("post_id", postId);
+        comment.put("parse_user", ParseUser.getCurrentUser());
+        comment.put("body", body);
+        aComments.add(comment);
+
+        scrollToMostRecentComment();
     }
 
     private void hideSoftKeyboard(View view){

--- a/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailActivity.java
+++ b/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailActivity.java
@@ -62,8 +62,12 @@ public class DetailActivity extends PostsListActivity implements DetailFragment.
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK && requestCode == REQUEST_CODE_OPEN_COMMENTS) {
             boolean newCommentCreated = data.getExtras().getBoolean("new_comment_created");
+            int numNewComments = data.getExtras().getInt("num_new_comments");
             if (newCommentCreated) {
-                detailFragment.refreshComments();
+                Log.wtf(TAG, "refreshing comments with "+numNewComments);
+                detailFragment.refreshComments(numNewComments);
+            } else {
+                Log.wtf(TAG, "no new comments");
             }
         }
 

--- a/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
+++ b/app/src/main/java/com/mycompany/traveljournal/detailsscreen/DetailFragment.java
@@ -416,12 +416,19 @@ public class DetailFragment extends TravelBaseFragment {
         this.openCommentsListener = openCommentsListener;
     }
 
-    public void refreshComments() {
+    public void refreshComments(int numNewComments) {
         // Clear Existing Comments
-        ViewGroup llComments = (ViewGroup) getActivity().findViewById(R.id.llComments);
-        llComments.removeAllViews();
+        //ViewGroup llComments = (ViewGroup) getActivity().findViewById(R.id.llComments);
+        //llComments.removeAllViews();
 
-        fetchAndPopulateComments(m_post);
+        //fetchAndPopulateComments(m_post);
+
+        //Update number of comments
+        Log.wtf(TAG, "refreshing comments, adding "+numNewComments);
+
+        int numComments = Integer.parseInt(tvNumComments.getText().toString());
+        numComments += numNewComments;
+        tvNumComments.setText(numComments+"");
     }
 
     // Mostly copied from http://guides.codepath.com/android/Sharing-Content-with-Intents


### PR DESCRIPTION
When creating a new comment, show new comment on comments list immediately without waiting for network.

After creating a comment and returning to detail page, update comment count locally without a network call.
